### PR TITLE
fix npm error because of wrong version formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios7translucent",
-  "version": "0.1",
+  "version": "0.0.1",
   "description": "Rebulid the iOS7 Translucent topbar in CSS using CSS Regions",
   "author": "Fabrice Weinberg",
   "license": "MIT",


### PR DESCRIPTION
Hey @FWeinb,

got an error cause of wrong version format in npm v2.9.1- i think its the current one.
This pr just addes a 0 to match semver.

Cheers
